### PR TITLE
fix: don't sync beta BASE tags to release; sync more tags to ff-test-dev repository

### DIFF
--- a/config-development.toml
+++ b/config-development.toml
@@ -30,7 +30,47 @@ destination_branch = "default"
 
 [[tag_mappings]]
 source_url = "https://github.com/mozilla-conduit/ff-test"
-tag_pattern = "^(FIREFOX|DEV)_(BETA|NIGHTLY)_(\\d+)_(BASE|END)$"
+tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_(BETA|NIGHTLY)_(\\d+)_(BASE|END)$"
+destination_url = "ssh://hg.mozilla.org/conduit-testing/ff-test-dev"
+tags_destination_branch = "dev-tags"
+# Default
+#tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
+
+[[tag_mappings]]
+source_url = "https://github.com/mozilla-conduit/ff-test"
+tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_(\\d+(_\\d+)+)b\\d+_(BUILD\\d+|RELEASE)$"
+destination_url = "ssh://hg.mozilla.org/conduit-testing/ff-test-dev"
+tags_destination_branch = "dev-tags"
+# Default
+#tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
+
+[[tag_mappings]]
+source_url = "https://github.com/mozilla-conduit/ff-test"
+tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_(\\d+)(_\\d+)+esr_(BUILD\\d+|RELEASE)$"
+destination_url = "ssh://hg.mozilla.org/conduit-testing/ff-test-dev"
+tags_destination_branch = "dev-tags"
+# Default
+#tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
+
+[[tag_mappings]]
+source_url = "https://github.com/mozilla-conduit/ff-test"
+tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_(\\d+(_\\d+)+)_(BUILD\\d+|RELEASE)$"
+destination_url = "ssh://hg.mozilla.org/conduit-testing/ff-test-dev"
+tags_destination_branch = "dev-tags"
+# Default
+#tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
+
+[[tag_mappings]]
+source_url = "https://github.com/mozilla-conduit/ff-test"
+tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_(\\d+(_\\d+)+)b\\d+_(BUILD\\d+|RELEASE)$"
+destination_url = "ssh://hg.mozilla.org/conduit-testing/ff-test-dev"
+tags_destination_branch = "dev-tags"
+# Default
+#tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
+
+[[tag_mappings]]
+source_url = "https://github.com/mozilla-conduit/ff-test"
+tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_RELEASE_(\\d+)+_(BASE|END)$"
 destination_url = "ssh://hg.mozilla.org/conduit-testing/ff-test-dev"
 tags_destination_branch = "dev-tags"
 # Default

--- a/config-production.toml
+++ b/config-production.toml
@@ -162,15 +162,6 @@ tags_destination_branch = "tags"
 # Default
 #tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
 
-[[tag_mappings]]
-source_url = "https://github.com/mozilla-firefox/firefox"
-# BETA_<M> BASE tags to mozilla-release
-tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_BETA_(\\d+)+_BASE$"
-destination_url = "ssh://hg.mozilla.org/betas/mozilla-release/"
-tags_destination_branch = "tags"
-# Default
-#tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
-
 #
 # relbranches
 #


### PR DESCRIPTION
Although we currently _do_ get the beta BASE tags in mozilla-release, this is actually a bug that I'd rather not propagate.

Additionally, I've added the tag patterns for central/beta/release/esr to `ff-test-dev`, so that I can test jobs from any release type there.

(In the near future, I would _very_ much like to set-up a more robust set up dev repositories that mirror central/beta/release/esr; but we can talk about that after the initial cut over.)