### PR TITLE
cinnabar: install latest changes from git-cinnabar upstream (Bug 1963805)

### DIFF
--- a/install_git-cinnabar.sh
+++ b/install_git-cinnabar.sh
@@ -2,6 +2,6 @@
 
 curl https://raw.githubusercontent.com/glandium/git-cinnabar/master/download.py -o download.py
 chmod u+x download.py
-./download.py --exact 0.7.2
+./download.py --exact 4beaf11666a48d5fac1660d6ceca09d1ffa406c6
 chmod a+x git-cinnabar
 chmod a+x git-remote-hg


### PR DESCRIPTION
Upgrade cinnabar to install the latest changes available in the
upstream repo. This works around a bug in cinnabar tag pushing.
