### PR TITLE
config: set `tag_mappings` to an empty list as default (Bug 1964441)

### DIFF
--- a/git_hg_sync/config.py
+++ b/git_hg_sync/config.py
@@ -41,7 +41,7 @@ class Config(pydantic.BaseModel):
     clones: ClonesConfig
     tracked_repositories: list[TrackedRepository]
     branch_mappings: list[BranchMapping]
-    tag_mappings: list[TagMapping]
+    tag_mappings: list[TagMapping] = []
 
     @pydantic.model_validator(mode="after")
     def verify_all_mappings_reference_tracked_repositories(


### PR DESCRIPTION
We removed the `tag_mappings` entries in the production config file,
however the Pydantic schema requires them to be set. Set a default
value for the `tag_mappings` field, to an empty list.

Pydantic is different from dataclasses, in that you can set a
mutable type to a default value and it will correctly perform
a deep copy so each instance of the class has a new default.
