### PR TITLE
repo_synchroniser: avoid non fast-forward and nothing changed issues (bug 1965991)

### DIFF
--- a/config-development.toml
+++ b/config-development.toml
@@ -42,7 +42,7 @@ destination_branch = "\\1"
 source_url = "https://github.com/mozilla-conduit/ff-test"
 tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_(BETA|NIGHTLY)_(\\d+)_(BASE|END)$"
 destination_url = "ssh://hg.mozilla.org/conduit-testing/ff-test-dev"
-tags_destination_branch = "dev-tags-bug1963805"
+tags_destination_branch = "tags-dev"
 # Default
 #tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
 
@@ -50,7 +50,7 @@ tags_destination_branch = "dev-tags-bug1963805"
 source_url = "https://github.com/mozilla-conduit/ff-test"
 tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_(\\d+(_\\d+)+)b\\d+_(BUILD\\d+|RELEASE)$"
 destination_url = "ssh://hg.mozilla.org/conduit-testing/ff-test-dev"
-tags_destination_branch = "dev-tags-bug1963805"
+tags_destination_branch = "tags-dev"
 # Default
 #tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
 
@@ -58,7 +58,7 @@ tags_destination_branch = "dev-tags-bug1963805"
 source_url = "https://github.com/mozilla-conduit/ff-test"
 tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_(\\d+)(_\\d+)+esr_(BUILD\\d+|RELEASE)$"
 destination_url = "ssh://hg.mozilla.org/conduit-testing/ff-test-dev"
-tags_destination_branch = "dev-tags-bug1963805"
+tags_destination_branch = "tags-dev"
 # Default
 #tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
 
@@ -66,7 +66,7 @@ tags_destination_branch = "dev-tags-bug1963805"
 source_url = "https://github.com/mozilla-conduit/ff-test"
 tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_(\\d+(_\\d+)+)_(BUILD\\d+|RELEASE)$"
 destination_url = "ssh://hg.mozilla.org/conduit-testing/ff-test-dev"
-tags_destination_branch = "dev-tags-bug1963805"
+tags_destination_branch = "tags-dev"
 # Default
 #tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
 
@@ -74,7 +74,7 @@ tags_destination_branch = "dev-tags-bug1963805"
 source_url = "https://github.com/mozilla-conduit/ff-test"
 tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_(\\d+(_\\d+)+)b\\d+_(BUILD\\d+|RELEASE)$"
 destination_url = "ssh://hg.mozilla.org/conduit-testing/ff-test-dev"
-tags_destination_branch = "dev-tags-bug1963805"
+tags_destination_branch = "tags-dev"
 # Default
 #tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
 
@@ -82,7 +82,7 @@ tags_destination_branch = "dev-tags-bug1963805"
 source_url = "https://github.com/mozilla-conduit/ff-test"
 tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_RELEASE_(\\d+)+_(BASE|END)$"
 destination_url = "ssh://hg.mozilla.org/conduit-testing/ff-test-dev"
-tags_destination_branch = "dev-tags-bug1963805"
+tags_destination_branch = "tags-dev"
 # Default
 #tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
 
@@ -101,6 +101,6 @@ destination_branch = "default"
 source_url = "https://github.com/mozilla-conduit/test-repo"
 tag_pattern = "^(DEV)_(BETA|NIGHTLY)_(\\d+)_(BASE|END)$"
 destination_url = "ssh://hg.mozilla.org/conduit-testing/test-repo-github-dev"
-tags_destination_branch = "dev-tags-bug1963805"
+tags_destination_branch = "tags-dev"
 # Default
 #tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"

--- a/config-production.toml
+++ b/config-production.toml
@@ -36,7 +36,7 @@ url = "https://github.com/mozilla-firefox/firefox.git"
 source_url = "https://github.com/mozilla-firefox/firefox.git"
 branch_pattern = "THIS_SHOULD_MATCH_NOTHING"
 destination_url = "https://hg.mozilla.org/mozilla-unified/"
-destination_branch = "default"
+destination_branch = "NOT_A_VALID_BRANCH"
 
 
 #
@@ -58,30 +58,30 @@ branch_pattern = "beta"
 destination_url = "ssh://hg.mozilla.org/releases/mozilla-beta/"
 destination_branch = "default"
 
-# [[tag_mappings]]
-# source_url = "https://github.com/mozilla-firefox/firefox.git"
-# # <M>_<m>(_<p>...)b<n> BUILD and RELEASE tags to mozilla-beta
-# tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_(\\d+(_\\d+)+)b\\d+_(BUILD\\d+|RELEASE)$"
-# destination_url = "ssh://hg.mozilla.org/releases/mozilla-beta/"
-# tags_destination_branch = "tags-beta"
-# # Default
-# #tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
-#
-# [[tag_mappings]]
-# source_url = "https://github.com/mozilla-firefox/firefox.git"
-# # BETA_<M> BASE and END tags to mozilla-beta
-# tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_BETA_(\\d+)+_(BASE|END)$"
-# destination_url = "ssh://hg.mozilla.org/releases/mozilla-beta/"
-# tags_destination_branch = "tags-beta"
-# # Default
-# #tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
-#
-# [[tag_mappings]]
-# source_url = "https://github.com/mozilla-firefox/firefox.git"
-# # RELEASE_<M> BASE tags to mozilla-beta
-# tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_RELEASE_(\\d+)+_BASE$"
-# destination_url = "ssh://hg.mozilla.org/releases/mozilla-beta/"
-# tags_destination_branch = "tags-beta"
+[[tag_mappings]]
+source_url = "https://github.com/mozilla-firefox/firefox.git"
+# <M>_<m>(_<p>...)b<n> BUILD and RELEASE tags to mozilla-beta
+tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_(\\d+(_\\d+)+)b\\d+_(BUILD\\d+|RELEASE)$"
+destination_url = "ssh://hg.mozilla.org/releases/mozilla-beta/"
+tags_destination_branch = "tags-beta"
+# Default
+#tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
+
+[[tag_mappings]]
+source_url = "https://github.com/mozilla-firefox/firefox.git"
+# BETA_<M> BASE and END tags to mozilla-beta
+tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_BETA_(\\d+)+_(BASE|END)$"
+destination_url = "ssh://hg.mozilla.org/releases/mozilla-beta/"
+tags_destination_branch = "tags-beta"
+# Default
+#tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
+
+[[tag_mappings]]
+source_url = "https://github.com/mozilla-firefox/firefox.git"
+# RELEASE_<M> BASE tags to mozilla-beta
+tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_RELEASE_(\\d+)+_BASE$"
+destination_url = "ssh://hg.mozilla.org/releases/mozilla-beta/"
+tags_destination_branch = "tags-beta"
 # Default
 #tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
 
@@ -96,12 +96,12 @@ branch_pattern = "^(esr\\d+)$"
 destination_url = "ssh://hg.mozilla.org/releases/mozilla-\\1/"
 destination_branch = "default"
 
-# [[tag_mappings]]
-# source_url = "https://github.com/mozilla-firefox/firefox.git"
-# # <M>_<m>(_<p>...)esr BUILD and RELEASE tags to mozilla-esr<M>
-# tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_(\\d+)(_\\d+)+esr_(BUILD\\d+|RELEASE)$"
-# destination_url = "ssh://hg.mozilla.org/releases/mozilla-esr\\2/"
-# tags_destination_branch = "tags-\\1"
+[[tag_mappings]]
+source_url = "https://github.com/mozilla-firefox/firefox.git"
+# <M>_<m>(_<p>...)esr BUILD and RELEASE tags to mozilla-esr<M>
+tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_(\\d+)(_\\d+)+esr_(BUILD\\d+|RELEASE)$"
+destination_url = "ssh://hg.mozilla.org/releases/mozilla-esr\\2/"
+tags_destination_branch = "tags-esr\\2"
 # Default
 #tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
 
@@ -125,12 +125,12 @@ branch_pattern = "main"
 destination_url = "ssh://hg.mozilla.org/mozilla-central/"
 destination_branch = "default"
 
-# [[tag_mappings]]
-# source_url = "https://github.com/mozilla-firefox/firefox.git"
-# # BETA_<M> and NIGHTLY_<M> tags to m-c
-# tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_(BETA|NIGHTLY)_(\\d+)_(BASE|END)$"
-# destination_url = "ssh://hg.mozilla.org/mozilla-central/"
-# tags_destination_branch = "tags-main"
+[[tag_mappings]]
+source_url = "https://github.com/mozilla-firefox/firefox.git"
+# BETA_<M> and NIGHTLY_<M> tags to m-c
+tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_(BETA|NIGHTLY)_(\\d+)_(BASE|END)$"
+destination_url = "ssh://hg.mozilla.org/mozilla-central/"
+tags_destination_branch = "tags-main"
 # Default
 #tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
 
@@ -144,21 +144,21 @@ branch_pattern = "release"
 destination_url = "ssh://hg.mozilla.org/releases/mozilla-release/"
 destination_branch = "default"
 
-# [[tag_mappings]]
-# source_url = "https://github.com/mozilla-firefox/firefox.git"
-# # <M>_<m>(_<p>...) BUILD and RELEASE tags to mozilla-release
-# tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_(\\d+(_\\d+)+)_(BUILD\\d+|RELEASE)$"
-# destination_url = "ssh://hg.mozilla.org/releases/mozilla-release/"
-# tags_destination_branch = "tags-release"
+[[tag_mappings]]
+source_url = "https://github.com/mozilla-firefox/firefox.git"
+# <M>_<m>(_<p>...) BUILD and RELEASE tags to mozilla-release
+tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_(\\d+(_\\d+)+)_(BUILD\\d+|RELEASE)$"
+destination_url = "ssh://hg.mozilla.org/releases/mozilla-release/"
+tags_destination_branch = "tags-release"
 # # Default
 # #tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
 #
-# [[tag_mappings]]
-# source_url = "https://github.com/mozilla-firefox/firefox.git"
-# # RELEASE_<M> BASE and END tags to mozilla-release
-# tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_RELEASE_(\\d+)+_(BASE|END)$"
-# destination_url = "ssh://hg.mozilla.org/releases/mozilla-release/"
-# tags_destination_branch = "tags-release"
+[[tag_mappings]]
+source_url = "https://github.com/mozilla-firefox/firefox.git"
+# RELEASE_<M> BASE and END tags to mozilla-release
+tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_RELEASE_(\\d+)+_(BASE|END)$"
+destination_url = "ssh://hg.mozilla.org/releases/mozilla-release/"
+tags_destination_branch = "tags-release"
 # Default
 #tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
 
@@ -202,11 +202,11 @@ branch_pattern = "autoland"
 destination_url = "ssh://hg.mozilla.org/conduit-testing/infra-testing/"
 destination_branch = "default"
 
-# [[tag_mappings]]
-# source_url = "https://github.com/mozilla-firefox/infra-testing.git"
-# tag_pattern = "TAGTESTING.*"
-# destination_url = "ssh://hg.mozilla.org/conduit-testing/infra-testing/"
-# tags_destination_branch = "tags-autoland"
+[[tag_mappings]]
+source_url = "https://github.com/mozilla-firefox/infra-testing.git"
+tag_pattern = ".+"
+destination_url = "ssh://hg.mozilla.org/conduit-testing/infra-testing/"
+tags_destination_branch = "tags-testing"
 # Default
 #tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
 
@@ -225,10 +225,10 @@ branch_pattern = ".+"
 destination_url = "ssh://hg.mozilla.org/conduit-testing/review/"
 destination_branch = "default"
 
-# [[tag_mappings]]
-# source_url = "https://github.com/mozilla-conduit/review.git"
-# tag_pattern = ".+"
-# destination_url = "ssh://hg.mozilla.org/conduit-testing/review/"
-# tags_destination_branch = "tags"
+[[tag_mappings]]
+source_url = "https://github.com/mozilla-conduit/review.git"
+tag_pattern = ".+"
+destination_url = "ssh://hg.mozilla.org/conduit-testing/review/"
+tags_destination_branch = "tags"
 # Default
 #tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"

--- a/config-production.toml
+++ b/config-production.toml
@@ -194,7 +194,7 @@ url = "https://github.com/mozilla-firefox/infra-testing.git"
 source_url = "https://github.com/mozilla-firefox/infra-testing.git"
 branch_pattern = "THIS_SHOULD_MATCH_NOTHING"
 destination_url = "https://hg.mozilla.org/mozilla-unified/"
-destination_branch = "default"
+destination_branch = "NOT_A_VALID_BRANCH"
 
 [[branch_mappings]]
 source_url = "https://github.com/mozilla-firefox/infra-testing.git"

--- a/git_hg_sync/repo_synchronizer.py
+++ b/git_hg_sync/repo_synchronizer.py
@@ -108,6 +108,7 @@ class RepoSynchronizer:
             if self._commit_has_mercurial_metadata(
                 repo, branch_operation.source_commit
             ):
+                breakpoint()
                 # Resolving the HG SHA is not sufficient, because we may know it from
                 # another repository, so we need to make sure it's not already present here.
                 hg_sha = self._git2hg(repo, branch_operation.source_commit)

--- a/git_hg_sync/repo_synchronizer.py
+++ b/git_hg_sync/repo_synchronizer.py
@@ -108,7 +108,6 @@ class RepoSynchronizer:
             if self._commit_has_mercurial_metadata(
                 repo, branch_operation.source_commit
             ):
-                breakpoint()
                 # Resolving the HG SHA is not sufficient, because we may know it from
                 # another repository, so we need to make sure it's not already present here.
                 hg_sha = self._git2hg(repo, branch_operation.source_commit)

--- a/git_hg_sync/repo_synchronizer.py
+++ b/git_hg_sync/repo_synchronizer.py
@@ -241,7 +241,7 @@ class RepoSynchronizer:
         # pushes update the metadata locally.
         #
         # WARNING: While we make a direct reference to `refs/cinnabar` here, it MUST NOT
-        # be used explicitely in subsequent git operations. This set of references get
+        # be used explicitly in subsequent git operations. This set of references get
         # updated on every `fetch`, and is therefore not stable enough to be trusted.
         #
         # Repo.git_dir is a PathLike union which is either a str, or a smarter thing. We

--- a/git_hg_sync/repo_synchronizer.py
+++ b/git_hg_sync/repo_synchronizer.py
@@ -111,7 +111,7 @@ class RepoSynchronizer:
                 # Resolving the HG SHA is not sufficient, because we may know it from
                 # another repository, so we need to make sure it's not already present here.
                 hg_sha = self._git2hg(repo, branch_operation.source_commit)
-                if hg_sha not in repo.git.execute(
+                if hg_sha in repo.git.execute(
                     [
                         "git",
                         "ls-remote",

--- a/tests/test_repo_synchronizer.py
+++ b/tests/test_repo_synchronizer.py
@@ -23,7 +23,16 @@ def tracked_repositories() -> list[TrackedRepository]:
 
 @pytest.fixture
 def hg_destination(tmp_path: Path) -> Path:
-    hg_remote_repo_path = tmp_path / "hg-remotes" / "myrepo"
+    return _hg_destination(tmp_path)
+
+
+@pytest.fixture
+def hg_destination_other(tmp_path: Path) -> Path:
+    return _hg_destination(tmp_path, "_other")
+
+
+def _hg_destination(tmp_path: Path, repo_suffix: str = "") -> Path:
+    hg_remote_repo_path = tmp_path / "hg-remotes" / f"myrepo{repo_suffix}"
     hg_remote_repo_path.mkdir(parents=True)
     subprocess.run(["hg", "init"], cwd=hg_remote_repo_path, check=True)
 
@@ -180,9 +189,59 @@ def test_sync_process_duplicate_tags(
     assert tag in tag_log
 
 
-def test_get_connection_and_queue(pulse_config: PulseConfig) -> None:
-    connection = get_connection(pulse_config)
-    queue = get_queue(pulse_config)
-    assert connection.userid == pulse_config.userid
-    assert connection.host == f"{pulse_config.host}:{pulse_config.port}"
-    assert queue.name == pulse_config.queue
+def test_sync_process_different_destination(
+    git_source: Repo,
+    hg_destination: Path,
+    hg_destination_other: Path,
+    tmp_path: Path,
+) -> None:
+    branch = "bar"
+    tag_branch = "tags"
+    tag = "mytag"
+    tag_suffix = "some suffix"
+
+    repo = Repo(git_source)
+
+    # Create a new commit on git repo
+    bar_path = git_source / "bar.txt"
+    bar_path.write_text("BAR CONTENT")
+    repo.index.add([bar_path])
+    git_commit_sha = repo.index.commit("add bar.txt").hexsha
+
+    # Sync new commit with mercurial repository
+    git_local_repo_path = tmp_path / "clones" / "myrepo"
+    syncrepos = RepoSynchronizer(git_local_repo_path, str(git_source))
+
+    request_user = "request_user@example.com"
+
+    operations: list[SyncBranchOperation | SyncTagOperation] = [
+        SyncBranchOperation(source_commit=git_commit_sha, destination_branch=branch),
+        SyncTagOperation(
+            source_commit=git_commit_sha,
+            tag=tag,
+            tags_destination_branch=tag_branch,
+            tag_message_suffix=tag_suffix,
+        ),
+    ]
+    syncrepos.sync(str(hg_destination), operations, request_user)
+
+    syncrepos.sync(str(hg_destination_other), operations, request_user)
+
+    # test
+    assert "BAR CONTENT" in hg_cat(hg_destination_other, "bar.txt", branch)
+
+    # XXX: In the current state, cinnabar refuses to re-create a tag which already
+    # exists anywhere in its working state. This means we can't duplicate an existing tag to a
+    # different destination. This is probably sane, as we should instead have a more
+    # controlled way of graduating tags to repos (e.g., to m-c).
+    #
+    # Leaving this here for later reference (and to support the discussion above).
+    #
+    # assert "BAR CONTENT" in hg_cat(hg_destination_other, "bar.txt", tag)
+    #
+    # test tag commit message
+    # tag_log = hg_log(hg_destination_other, tag_branch, ["-T", "{desc}"])
+    # assert "No bug - Tagging" in tag_log
+    # assert tag_suffix in tag_log
+    # assert tag in tag_log
+    # assert hg_rev(hg_destination_other, branch) in tag_log

--- a/tests/test_repo_synchronizer.py
+++ b/tests/test_repo_synchronizer.py
@@ -245,3 +245,11 @@ def test_sync_process_different_destination(
     # assert tag_suffix in tag_log
     # assert tag in tag_log
     # assert hg_rev(hg_destination_other, branch) in tag_log
+
+
+def test_get_connection_and_queue(pulse_config: PulseConfig) -> None:
+    connection = get_connection(pulse_config)
+    queue = get_queue(pulse_config)
+    assert connection.userid == pulse_config.userid
+    assert connection.host == f"{pulse_config.host}:{pulse_config.port}"
+    assert queue.name == pulse_config.queue


### PR DESCRIPTION
This may happen when reprocessing old messages.

This PR is currently a WIP, as we are reaching the limits of what we can reasonably do on the user-side of cinnabar. 

Waiting for a `git cinnabar push` command (see https://github.com/glandium/git-cinnabar/issues/358) to do most of the checks attempted here.