### PR TITLE
repo_synchroniser: pass request_user as GIT_AUTHOR_* (bug 1963491)

### DIFF
--- a/git_hg_sync/repo_synchronizer.py
+++ b/git_hg_sync/repo_synchronizer.py
@@ -91,7 +91,11 @@ class RepoSynchronizer:
                 raise RepoSyncError(branch_operation, e) from e
 
         os.environ[REQUEST_USER_ENV_VAR] = request_user
-        logger.debug(f"{REQUEST_USER_ENV_VAR} set to {request_user}")
+        os.environ["GIT_AUTHOR_EMAIL"] = request_user
+        # We don't have the author name in the Pulse message, so we reuse the email
+        # address.
+        os.environ["GIT_AUTHOR_NAME"] = request_user
+        logger.debug(f"{REQUEST_USER_ENV_VAR} and GIT_AUTHOR_* set to {request_user}")
 
         # Add mercurial metadata to new commits from synced branches
         # Some of these commits could be tagged in the same synchronization and

--- a/git_hg_sync/repo_synchronizer.py
+++ b/git_hg_sync/repo_synchronizer.py
@@ -92,9 +92,12 @@ class RepoSynchronizer:
 
         os.environ[REQUEST_USER_ENV_VAR] = request_user
         os.environ["GIT_AUTHOR_EMAIL"] = request_user
-        # We don't have the author name in the Pulse message, so we reuse the email
+        # We don't have the author name in the Pulse message, so we guess from the email
         # address.
-        os.environ["GIT_AUTHOR_NAME"] = request_user
+        userinfo = request_user
+        if "@" in userinfo:
+            userinfo, _ = request_user.split("@")
+        os.environ["GIT_AUTHOR_NAME"] = userinfo
         logger.debug(f"{REQUEST_USER_ENV_VAR} and GIT_AUTHOR_* set to {request_user}")
 
         # Add mercurial metadata to new commits from synced branches

--- a/tests/test_repo_synchronizer.py
+++ b/tests/test_repo_synchronizer.py
@@ -103,6 +103,9 @@ def test_sync_process_(
     assert tag in tag_log
     assert hg_rev(hg_destination, branch) in tag_log
 
+    tag_author = hg_log(hg_destination, tag_branch, ["-T", "{author}"])
+    assert request_user in tag_author
+
 
 def test_sync_process_duplicate_tags(
     git_source: Repo,

--- a/tests/test_repo_synchronizer.py
+++ b/tests/test_repo_synchronizer.py
@@ -58,7 +58,7 @@ def git_source(hg_destination: Path, tmp_path: Path) -> Path:
     return git_remote_repo_path
 
 
-def test_sync_process_(
+def test_sync_process(
     git_source: Repo,
     hg_destination: Path,
     tmp_path: Path,
@@ -90,6 +90,7 @@ def test_sync_process_(
     ]
 
     request_user = "request_user@example.com"
+    user_info = "request_user"  # The part before the @ in request_user.
     syncrepos.sync(str(hg_destination), operations, request_user)
 
     # test
@@ -104,7 +105,7 @@ def test_sync_process_(
     assert hg_rev(hg_destination, branch) in tag_log
 
     tag_author = hg_log(hg_destination, tag_branch, ["-T", "{author}"])
-    assert request_user in tag_author
+    assert f"{user_info} <{request_user}>" in tag_author
 
 
 def test_sync_process_duplicate_tags(


### PR DESCRIPTION
This allows us to record a better author name when creating the Hg tags.