### PR TITLE
Fix destination branch for esr tags (bug 1967193)

### DIFF
--- a/git_hg_sync/mapping.py
+++ b/git_hg_sync/mapping.py
@@ -105,13 +105,16 @@ class TagMapping(Mapping):
             if not self._tag_pattern.match(tag_name):
                 continue
             destination_url = re.sub(self._tag_pattern, self.destination_url, tag_name)
+            tags_destination_branch = re.sub(
+                self._tag_pattern, self.tags_destination_branch, tag_name
+            )
             matches.append(
                 MappingMatch(
                     destination_url=destination_url,
                     operation=SyncTagOperation(
                         tag=tag_name,
                         source_commit=commit,
-                        tags_destination_branch=self.tags_destination_branch,
+                        tags_destination_branch=tags_destination_branch,
                         tag_message_suffix=self.tag_message_suffix,
                     ),
                 )


### PR DESCRIPTION
tags_destination_branch can be a regexp in which case backslash escapes have to be processed, otherwise we try to create a branch with an invalid name.