### PR TITLE
retry: log warning rather than error when an attempt will get retried

### DIFF
--- a/git_hg_sync/retry.py
+++ b/git_hg_sync/retry.py
@@ -22,7 +22,7 @@ def retry(
         except Exception as exc:
             action_text = f" {action}" if action else ""
             if attempt < tries:
-                logger.error(
+                logger.warning(
                     f"Failed attempt{action_text} [{attempt}/{tries}] failed with error: {type(exc).__name__}: {exc}. Retrying..."
                 )
                 if delay > 0:


### PR DESCRIPTION
This makes it clearer in the logs whether something is a worry or not.