### PR TITLE
config-prod: restore use of tags-unified branch for all repos (bug 1973879)

### DIFF
--- a/config-production.toml
+++ b/config-production.toml
@@ -63,7 +63,7 @@ source_url = "https://github.com/mozilla-firefox/firefox.git"
 # <M>_<m>(_<p>...)b<n> BUILD and RELEASE tags to mozilla-beta
 tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_(\\d+(_\\d+)+)b\\d+_(BUILD\\d+|RELEASE)$"
 destination_url = "ssh://hg.mozilla.org/releases/mozilla-beta/"
-tags_destination_branch = "tags-beta"
+tags_destination_branch = "tags-unified"
 # Default
 #tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
 
@@ -72,7 +72,7 @@ source_url = "https://github.com/mozilla-firefox/firefox.git"
 # BETA_<M> BASE and END tags to mozilla-beta
 tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_BETA_(\\d+)+_(BASE|END)$"
 destination_url = "ssh://hg.mozilla.org/releases/mozilla-beta/"
-tags_destination_branch = "tags-beta"
+tags_destination_branch = "tags-unified"
 # Default
 #tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
 
@@ -81,7 +81,7 @@ source_url = "https://github.com/mozilla-firefox/firefox.git"
 # RELEASE_<M> BASE tags to mozilla-beta
 tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_RELEASE_(\\d+)+_BASE$"
 destination_url = "ssh://hg.mozilla.org/releases/mozilla-beta/"
-tags_destination_branch = "tags-beta"
+tags_destination_branch = "tags-unified"
 # Default
 #tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
 
@@ -101,7 +101,7 @@ source_url = "https://github.com/mozilla-firefox/firefox.git"
 # <M>_<m>(_<p>...)esr BUILD and RELEASE tags to mozilla-esr<M>
 tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_(\\d+)(_\\d+)+esr_(BUILD\\d+|RELEASE)$"
 destination_url = "ssh://hg.mozilla.org/releases/mozilla-esr\\2/"
-tags_destination_branch = "tags-esr\\2"
+tags_destination_branch = "tags-unified"
 # Default
 #tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
 
@@ -130,19 +130,18 @@ source_url = "https://github.com/mozilla-firefox/firefox.git"
 # NIGHTLY_<M> tags to m-c
 tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_NIGHTLY_(\\d+)_(BASE|END)$"
 destination_url = "ssh://hg.mozilla.org/mozilla-central/"
-tags_destination_branch = "tags-main"
+tags_destination_branch = "tags-unified"
 # Default
 # tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
 
-# BETA tags syncing disabled for central due to bug 1968531.
-# [[tag_mappings]]
-# source_url = "https://github.com/mozilla-firefox/firefox.git"
-# # BETA_<M>_BASE tags to m-c (in the past, we didn't sync BETA_END, only _BASE)
-# tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_BETA_(\\d+)_BASE$"
-# destination_url = "ssh://hg.mozilla.org/mozilla-central/"
-# tags_destination_branch = "tags-main"
-# # Default
-# #tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
+[[tag_mappings]]
+source_url = "https://github.com/mozilla-firefox/firefox.git"
+# BETA_<M>_BASE tags to m-c (in the past, we didn't sync BETA_END, only _BASE)
+tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_BETA_(\\d+)_BASE$"
+destination_url = "ssh://hg.mozilla.org/mozilla-central/"
+tags_destination_branch = "tags-unified"
+# Default
+#tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
 
 
 #
@@ -159,7 +158,7 @@ source_url = "https://github.com/mozilla-firefox/firefox.git"
 # <M>_<m>(_<p>...) BUILD and RELEASE tags to mozilla-release
 tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_(\\d+(_\\d+)+)_(BUILD\\d+|RELEASE)$"
 destination_url = "ssh://hg.mozilla.org/releases/mozilla-release/"
-tags_destination_branch = "tags-release"
+tags_destination_branch = "tags-unified"
 # # Default
 # #tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
 #
@@ -168,7 +167,7 @@ source_url = "https://github.com/mozilla-firefox/firefox.git"
 # RELEASE_<M> BASE and END tags to mozilla-release
 tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_RELEASE_(\\d+)+_(BASE|END)$"
 destination_url = "ssh://hg.mozilla.org/releases/mozilla-release/"
-tags_destination_branch = "tags-release"
+tags_destination_branch = "tags-unified"
 # Default
 #tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
 


### PR DESCRIPTION
Now that the repos hooks have been fixed to allow the creation of the orphan tags branch (in bug 1978262), we can restore the configuration that relies on it.

This reverts commit b28fd85d94a0210be1882ab9d0cccd488a8b677b.