### PR TITLE
config: sync all tags to all repos (bug 1979342, bug 1962599)

### DIFF
--- a/config-development.toml
+++ b/config-development.toml
@@ -40,52 +40,11 @@ destination_branch = "\\1"
 
 [[tag_mappings]]
 source_url = "https://github.com/mozilla-conduit/ff-test"
-tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_(BETA|NIGHTLY)_(\\d+)_(BASE|END)$"
+tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_.*$"
 destination_url = "ssh://hg.mozilla.org/conduit-testing/ff-test-dev"
 tags_destination_branch = "tags-unified-1973880"
 # Default
 #tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
-
-[[tag_mappings]]
-source_url = "https://github.com/mozilla-conduit/ff-test"
-tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_(\\d+(_\\d+)+)b\\d+_(BUILD\\d+|RELEASE)$"
-destination_url = "ssh://hg.mozilla.org/conduit-testing/ff-test-dev"
-tags_destination_branch = "tags-unified-1973880"
-# Default
-#tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
-
-[[tag_mappings]]
-source_url = "https://github.com/mozilla-conduit/ff-test"
-tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_(\\d+)(_\\d+)+esr_(BUILD\\d+|RELEASE)$"
-destination_url = "ssh://hg.mozilla.org/conduit-testing/ff-test-dev"
-tags_destination_branch = "tags-unified-1973880"
-# Default
-#tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
-
-[[tag_mappings]]
-source_url = "https://github.com/mozilla-conduit/ff-test"
-tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_(\\d+(_\\d+)+)_(BUILD\\d+|RELEASE)$"
-destination_url = "ssh://hg.mozilla.org/conduit-testing/ff-test-dev"
-tags_destination_branch = "tags-unified-1973880"
-# Default
-#tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
-
-[[tag_mappings]]
-source_url = "https://github.com/mozilla-conduit/ff-test"
-tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_(\\d+(_\\d+)+)b\\d+_(BUILD\\d+|RELEASE)$"
-destination_url = "ssh://hg.mozilla.org/conduit-testing/ff-test-dev"
-tags_destination_branch = "tags-unified-1973880"
-# Default
-#tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
-
-[[tag_mappings]]
-source_url = "https://github.com/mozilla-conduit/ff-test"
-tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_RELEASE_(\\d+)+_(BASE|END)$"
-destination_url = "ssh://hg.mozilla.org/conduit-testing/ff-test-dev"
-tags_destination_branch = "tags-unified-1973880"
-# Default
-#tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
-
 
 [[tracked_repositories]]
 name = "test-repo-github"

--- a/config-production.toml
+++ b/config-production.toml
@@ -38,7 +38,6 @@ branch_pattern = "THIS_SHOULD_MATCH_NOTHING"
 destination_url = "https://hg.mozilla.org/mozilla-unified/"
 destination_branch = "NOT_A_VALID_BRANCH"
 
-
 #
 # AUTOLAND
 #
@@ -61,25 +60,7 @@ destination_branch = "default"
 [[tag_mappings]]
 source_url = "https://github.com/mozilla-firefox/firefox.git"
 # <M>_<m>(_<p>...)b<n> BUILD and RELEASE tags to mozilla-beta
-tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_(\\d+(_\\d+)+)b\\d+_(BUILD\\d+|RELEASE)$"
-destination_url = "ssh://hg.mozilla.org/releases/mozilla-beta/"
-tags_destination_branch = "tags-unified"
-# Default
-#tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
-
-[[tag_mappings]]
-source_url = "https://github.com/mozilla-firefox/firefox.git"
-# BETA_<M> BASE and END tags to mozilla-beta
-tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_BETA_(\\d+)+_(BASE|END)$"
-destination_url = "ssh://hg.mozilla.org/releases/mozilla-beta/"
-tags_destination_branch = "tags-unified"
-# Default
-#tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
-
-[[tag_mappings]]
-source_url = "https://github.com/mozilla-firefox/firefox.git"
-# RELEASE_<M> BASE tags to mozilla-beta
-tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_RELEASE_(\\d+)+_BASE$"
+tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_.*$"
 destination_url = "ssh://hg.mozilla.org/releases/mozilla-beta/"
 tags_destination_branch = "tags-unified"
 # Default
@@ -96,6 +77,9 @@ branch_pattern = "^(esr\\d+)$"
 destination_url = "ssh://hg.mozilla.org/releases/mozilla-\\1/"
 destination_branch = "default"
 
+# We can only sync the tags branch to ESR when an ESR-specific tag is added.
+# When such a sync happens, all non-ESR tags currently present on that branch
+# will also be pushed to the target ESR repo.
 [[tag_mappings]]
 source_url = "https://github.com/mozilla-firefox/firefox.git"
 # <M>_<m>(_<p>...)esr BUILD and RELEASE tags to mozilla-esr<M>
@@ -106,7 +90,7 @@ tags_destination_branch = "tags-unified"
 #tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
 
 #
-# relbranches
+# ESR relbranches
 #
 [[branch_mappings]]
 source_url = "https://github.com/mozilla-firefox/firefox.git"
@@ -128,20 +112,11 @@ destination_branch = "default"
 [[tag_mappings]]
 source_url = "https://github.com/mozilla-firefox/firefox.git"
 # NIGHTLY_<M> tags to m-c
-tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_NIGHTLY_(\\d+)_(BASE|END)$"
+tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_.*$"
 destination_url = "ssh://hg.mozilla.org/mozilla-central/"
 tags_destination_branch = "tags-unified"
 # Default
 # tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
-
-[[tag_mappings]]
-source_url = "https://github.com/mozilla-firefox/firefox.git"
-# BETA_<M>_BASE tags to m-c (in the past, we didn't sync BETA_END, only _BASE)
-tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_BETA_(\\d+)_BASE$"
-destination_url = "ssh://hg.mozilla.org/mozilla-central/"
-tags_destination_branch = "tags-unified"
-# Default
-#tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
 
 
 #
@@ -156,23 +131,14 @@ destination_branch = "default"
 [[tag_mappings]]
 source_url = "https://github.com/mozilla-firefox/firefox.git"
 # <M>_<m>(_<p>...) BUILD and RELEASE tags to mozilla-release
-tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_(\\d+(_\\d+)+)_(BUILD\\d+|RELEASE)$"
+tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_.*$"
 destination_url = "ssh://hg.mozilla.org/releases/mozilla-release/"
 tags_destination_branch = "tags-unified"
 # # Default
 # #tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
-#
-[[tag_mappings]]
-source_url = "https://github.com/mozilla-firefox/firefox.git"
-# RELEASE_<M> BASE and END tags to mozilla-release
-tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_RELEASE_(\\d+)+_(BASE|END)$"
-destination_url = "ssh://hg.mozilla.org/releases/mozilla-release/"
-tags_destination_branch = "tags-unified"
-# Default
-#tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
 
 #
-# relbranches
+# RELEASE relbranches
 #
 [[branch_mappings]]
 source_url = "https://github.com/mozilla-firefox/firefox.git"

--- a/config-production.toml
+++ b/config-production.toml
@@ -93,7 +93,7 @@ tags_destination_branch = "tags-unified"
 #
 [[branch_mappings]]
 source_url = "https://github.com/mozilla-firefox/firefox.git"
-# ESR_<M>_<m>_X RELBRANCH to mozilla-release matching branch
+# ESR_<M>_<m>_X RELBRANCH to mozilla-esr<M> matching branch
 branch_pattern = "^((FIREFOX|DEVEDITION|FIREFOX-ANDROID)_ESR_(\\d+)(_\\d+_X)_RELBRANCH)$"
 destination_url = "ssh://hg.mozilla.org/releases/mozilla-esr\\3/"
 destination_branch = "\\1"

--- a/config-production.toml
+++ b/config-production.toml
@@ -59,7 +59,6 @@ destination_branch = "default"
 
 [[tag_mappings]]
 source_url = "https://github.com/mozilla-firefox/firefox.git"
-# <M>_<m>(_<p>...)b<n> BUILD and RELEASE tags to mozilla-beta
 tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_.*$"
 destination_url = "ssh://hg.mozilla.org/releases/mozilla-beta/"
 tags_destination_branch = "tags-unified"
@@ -111,7 +110,6 @@ destination_branch = "default"
 
 [[tag_mappings]]
 source_url = "https://github.com/mozilla-firefox/firefox.git"
-# NIGHTLY_<M> tags to m-c
 tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_.*$"
 destination_url = "ssh://hg.mozilla.org/mozilla-central/"
 tags_destination_branch = "tags-unified"
@@ -130,7 +128,6 @@ destination_branch = "default"
 
 [[tag_mappings]]
 source_url = "https://github.com/mozilla-firefox/firefox.git"
-# <M>_<m>(_<p>...) BUILD and RELEASE tags to mozilla-release
 tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_.*$"
 destination_url = "ssh://hg.mozilla.org/releases/mozilla-release/"
 tags_destination_branch = "tags-unified"

--- a/config-production.toml
+++ b/config-production.toml
@@ -93,7 +93,7 @@ tags_destination_branch = "tags-unified"
 #
 [[branch_mappings]]
 source_url = "https://github.com/mozilla-firefox/firefox.git"
-# <M>_<m>_X RELBRANCH to mozilla-release matching branch
+# ESR_<M>_<m>_X RELBRANCH to mozilla-release matching branch
 branch_pattern = "^((FIREFOX|DEVEDITION|FIREFOX-ANDROID)_ESR_(\\d+)(_\\d+_X)_RELBRANCH)$"
 destination_url = "ssh://hg.mozilla.org/releases/mozilla-esr\\3/"
 destination_branch = "\\1"


### PR DESCRIPTION
@jcristau suggested to sync all tags to all repos unconditionally, as a way to avoid having multiple `tags-unified` at different points in various repos on Hg.

Note: we cannot do this fully for ESRs, as the name of the target repo is derived from the tag getting created. Those will continue working as before, in that the `tags-unified` branch will receive all the tags up to the most recent ESR tag for that repo. They will often continue lag behind m-c, beta and release.

As a side note, now that we have all tags synced to m-c all the time, this provides a partial solution to the bootstrapping problem of bug 1962599. However, some implementation work is still required to leverage it (by fetching the tags from mozilla-central when bootstrapping).