### PR TITLE
Revert "config: sync all tags to all repos (bug 1979342, bug 1962599)  (#68)" (bug 1980181)

### DIFF
--- a/config-development.toml
+++ b/config-development.toml
@@ -40,11 +40,52 @@ destination_branch = "\\1"
 
 [[tag_mappings]]
 source_url = "https://github.com/mozilla-conduit/ff-test"
-tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_.*$"
+tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_(BETA|NIGHTLY)_(\\d+)_(BASE|END)$"
 destination_url = "ssh://hg.mozilla.org/conduit-testing/ff-test-dev"
 tags_destination_branch = "tags-unified-1973880"
 # Default
 #tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
+
+[[tag_mappings]]
+source_url = "https://github.com/mozilla-conduit/ff-test"
+tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_(\\d+(_\\d+)+)b\\d+_(BUILD\\d+|RELEASE)$"
+destination_url = "ssh://hg.mozilla.org/conduit-testing/ff-test-dev"
+tags_destination_branch = "tags-unified-1973880"
+# Default
+#tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
+
+[[tag_mappings]]
+source_url = "https://github.com/mozilla-conduit/ff-test"
+tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_(\\d+)(_\\d+)+esr_(BUILD\\d+|RELEASE)$"
+destination_url = "ssh://hg.mozilla.org/conduit-testing/ff-test-dev"
+tags_destination_branch = "tags-unified-1973880"
+# Default
+#tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
+
+[[tag_mappings]]
+source_url = "https://github.com/mozilla-conduit/ff-test"
+tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_(\\d+(_\\d+)+)_(BUILD\\d+|RELEASE)$"
+destination_url = "ssh://hg.mozilla.org/conduit-testing/ff-test-dev"
+tags_destination_branch = "tags-unified-1973880"
+# Default
+#tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
+
+[[tag_mappings]]
+source_url = "https://github.com/mozilla-conduit/ff-test"
+tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_(\\d+(_\\d+)+)b\\d+_(BUILD\\d+|RELEASE)$"
+destination_url = "ssh://hg.mozilla.org/conduit-testing/ff-test-dev"
+tags_destination_branch = "tags-unified-1973880"
+# Default
+#tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
+
+[[tag_mappings]]
+source_url = "https://github.com/mozilla-conduit/ff-test"
+tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_RELEASE_(\\d+)+_(BASE|END)$"
+destination_url = "ssh://hg.mozilla.org/conduit-testing/ff-test-dev"
+tags_destination_branch = "tags-unified-1973880"
+# Default
+#tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
+
 
 [[tracked_repositories]]
 name = "test-repo-github"

--- a/config-production.toml
+++ b/config-production.toml
@@ -38,6 +38,7 @@ branch_pattern = "THIS_SHOULD_MATCH_NOTHING"
 destination_url = "https://hg.mozilla.org/mozilla-unified/"
 destination_branch = "NOT_A_VALID_BRANCH"
 
+
 #
 # AUTOLAND
 #
@@ -59,7 +60,26 @@ destination_branch = "default"
 
 [[tag_mappings]]
 source_url = "https://github.com/mozilla-firefox/firefox.git"
-tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_.*$"
+# <M>_<m>(_<p>...)b<n> BUILD and RELEASE tags to mozilla-beta
+tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_(\\d+(_\\d+)+)b\\d+_(BUILD\\d+|RELEASE)$"
+destination_url = "ssh://hg.mozilla.org/releases/mozilla-beta/"
+tags_destination_branch = "tags-unified"
+# Default
+#tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
+
+[[tag_mappings]]
+source_url = "https://github.com/mozilla-firefox/firefox.git"
+# BETA_<M> BASE and END tags to mozilla-beta
+tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_BETA_(\\d+)+_(BASE|END)$"
+destination_url = "ssh://hg.mozilla.org/releases/mozilla-beta/"
+tags_destination_branch = "tags-unified"
+# Default
+#tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
+
+[[tag_mappings]]
+source_url = "https://github.com/mozilla-firefox/firefox.git"
+# RELEASE_<M> BASE tags to mozilla-beta
+tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_RELEASE_(\\d+)+_BASE$"
 destination_url = "ssh://hg.mozilla.org/releases/mozilla-beta/"
 tags_destination_branch = "tags-unified"
 # Default
@@ -76,9 +96,6 @@ branch_pattern = "^(esr\\d+)$"
 destination_url = "ssh://hg.mozilla.org/releases/mozilla-\\1/"
 destination_branch = "default"
 
-# We can only sync the tags branch to ESR when an ESR-specific tag is added.
-# When such a sync happens, all non-ESR tags currently present on that branch
-# will also be pushed to the target ESR repo.
 [[tag_mappings]]
 source_url = "https://github.com/mozilla-firefox/firefox.git"
 # <M>_<m>(_<p>...)esr BUILD and RELEASE tags to mozilla-esr<M>
@@ -89,11 +106,11 @@ tags_destination_branch = "tags-unified"
 #tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
 
 #
-# ESR relbranches
+# relbranches
 #
 [[branch_mappings]]
 source_url = "https://github.com/mozilla-firefox/firefox.git"
-# ESR_<M>_<m>_X RELBRANCH to mozilla-esr<M> matching branch
+# <M>_<m>_X RELBRANCH to mozilla-release matching branch
 branch_pattern = "^((FIREFOX|DEVEDITION|FIREFOX-ANDROID)_ESR_(\\d+)(_\\d+_X)_RELBRANCH)$"
 destination_url = "ssh://hg.mozilla.org/releases/mozilla-esr\\3/"
 destination_branch = "\\1"
@@ -110,11 +127,21 @@ destination_branch = "default"
 
 [[tag_mappings]]
 source_url = "https://github.com/mozilla-firefox/firefox.git"
-tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_.*$"
+# NIGHTLY_<M> tags to m-c
+tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_NIGHTLY_(\\d+)_(BASE|END)$"
 destination_url = "ssh://hg.mozilla.org/mozilla-central/"
 tags_destination_branch = "tags-unified"
 # Default
 # tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
+
+[[tag_mappings]]
+source_url = "https://github.com/mozilla-firefox/firefox.git"
+# BETA_<M>_BASE tags to m-c (in the past, we didn't sync BETA_END, only _BASE)
+tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_BETA_(\\d+)_BASE$"
+destination_url = "ssh://hg.mozilla.org/mozilla-central/"
+tags_destination_branch = "tags-unified"
+# Default
+#tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
 
 
 #
@@ -128,14 +155,24 @@ destination_branch = "default"
 
 [[tag_mappings]]
 source_url = "https://github.com/mozilla-firefox/firefox.git"
-tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_.*$"
+# <M>_<m>(_<p>...) BUILD and RELEASE tags to mozilla-release
+tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_(\\d+(_\\d+)+)_(BUILD\\d+|RELEASE)$"
 destination_url = "ssh://hg.mozilla.org/releases/mozilla-release/"
 tags_destination_branch = "tags-unified"
 # # Default
 # #tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
+#
+[[tag_mappings]]
+source_url = "https://github.com/mozilla-firefox/firefox.git"
+# RELEASE_<M> BASE and END tags to mozilla-release
+tag_pattern = "^(FIREFOX|DEVEDITION|FIREFOX-ANDROID)_RELEASE_(\\d+)+_(BASE|END)$"
+destination_url = "ssh://hg.mozilla.org/releases/mozilla-release/"
+tags_destination_branch = "tags-unified"
+# Default
+#tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
 
 #
-# RELEASE relbranches
+# relbranches
 #
 [[branch_mappings]]
 source_url = "https://github.com/mozilla-firefox/firefox.git"


### PR DESCRIPTION
This reverts commit a0bbb1285af19f9364190293dc1106287a2ffd88.

Bug 1963745 needs to be fixed first, before we can apply this change, otherwise this is the cause of bug 1980181.