### PR TITLE
config: add configurable heartbeat for pulse (bug 1963745)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ variables:
 - PULSE_QUEUE
 - PULSE_ROUTING_KEY
 - PULSE_SSL (needs to be an empty string to be False, otherwise True)
+- PULSE_HEARTBEAT (needs to be an integer)
 - PULSE_USERID
 
 ### SSH key

--- a/config-development.toml
+++ b/config-development.toml
@@ -9,6 +9,7 @@ password = "SET THIS IN PULSE_PASSWORD ENV VARIABLE"
 exchange = "exchange/landodev/pushes"
 routing_key = "gitpushes"
 # The Consumer declares the queue and binds it to the exchange.
+heartbeat = 30
 queue = "queue/githgsyncdev/pushes"
 
 [sentry]

--- a/config-docker.toml
+++ b/config-docker.toml
@@ -6,6 +6,7 @@ exchange = "exchange/git-hg-sync/test"
 routing_key = "git-hg-sync"
 queue = "queue/git-hg-sync/sync"
 password = "guest"
+heartbeat = 30
 ssl = false
 
 [sentry]

--- a/config-production.toml
+++ b/config-production.toml
@@ -9,6 +9,7 @@ password = "SET THIS IN PULSE_PASSWORD ENV VARIABLE"
 exchange = "exchange/landoprod/pushes"
 routing_key = "gitpushes"
 # The Consumer declares the queue and binds it to the exchange.
+heartbeat = 30
 queue = "queue/githgsyncprod/pushes"
 
 [sentry]

--- a/config-staging.toml
+++ b/config-staging.toml
@@ -9,6 +9,7 @@ password = "SET THIS IN PULSE_PASSWORD ENV VARIABLE"
 exchange = "exchange/landostage/pushes"
 routing_key = "gitpushes"
 # The Consumer declares the queue and binds it to the exchange.
+heartbeat = 30
 queue = "queue/githgsyncstage/pushes"
 
 [sentry]

--- a/config.toml.example
+++ b/config.toml.example
@@ -6,6 +6,7 @@ exchange = "exchange/<username>/test"
 routing_key = ""
 queue = "queue/<username>/test"
 password = "<pulse-password>"
+heartbeat = 30
 ssl = true
 
 [sentry]

--- a/git_hg_sync/__main__.py
+++ b/git_hg_sync/__main__.py
@@ -31,7 +31,7 @@ def get_connection(config: PulseConfig) -> Connection:
         port=config.port,
         userid=config.userid,
         password=config.password,
-        heartbeat=10,
+        heartbeat=config.heartbeat,
         ssl=config.ssl,
     )
 

--- a/git_hg_sync/config.py
+++ b/git_hg_sync/config.py
@@ -19,6 +19,7 @@ class PulseConfig(pydantic.BaseModel):
     routing_key: str
     queue: str
     password: str
+    heartbeat: int
     ssl: bool
 
 

--- a/git_hg_sync/pulse_worker.py
+++ b/git_hg_sync/pulse_worker.py
@@ -21,8 +21,9 @@ class EntityTypeError(Exception):
 
 
 class PulseWorker(ConsumerMixin):
-    event_handler: EventHandler | None
     """Function that will be called whenever an event is received"""
+
+    event_handler: EventHandler | None
 
     def __init__(
         self,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,14 @@
 import sys
+from collections.abc import Callable
+from pathlib import Path
 
 import mozlog
 import mozlog.formatters
 import mozlog.handlers
 import pytest
 
-from git_hg_sync.config import PulseConfig
+from git_hg_sync.config import ClonesConfig, Config, PulseConfig, TrackedRepository
+from git_hg_sync.mapping import BranchMapping
 
 
 @pytest.fixture(autouse=True, scope="session")
@@ -27,5 +30,42 @@ def pulse_config() -> PulseConfig:
         routing_key="#",
         queue="queue/guest/test",
         password="guest",
+        heartbeat=30,
         ssl=False,
     )
+
+@pytest.fixture
+def test_config(pulse_config: PulseConfig) -> Config:
+    return Config(
+        pulse=pulse_config,
+        clones=ClonesConfig(directory=Path("clones")),
+        tracked_repositories=[
+            TrackedRepository(name="mozilla-central", url="https://github.com/mozilla-firefox/firefox.git"),
+        ],
+        branch_mappings=[BranchMapping(
+            branch_pattern = '.*',
+            source_url = "https://github.com/mozilla-firefox/firefox.git",
+            destination_url = 'destination_url',
+            destination_branch  = 'destination_branch',
+        )],
+    )
+
+@pytest.fixture
+def get_payload() -> Callable:
+
+    def get_payload(**kwargs: dict) -> dict:
+        """Return a default payload, with override via kwargs."""
+        payload = {
+            "type": "push",
+            "repo_url": "repo.git",
+            "branches": { "main": 40 * "0"},
+            "tags": {},
+            "time": 0,
+            "push_id": 0,
+            "user": "user",
+            "push_json_url": "push_json_url",
+        }
+        payload.update(kwargs)
+        return payload
+
+    return get_payload

--- a/tests/data/config.toml
+++ b/tests/data/config.toml
@@ -6,6 +6,7 @@ exchange = "exchange/guest/test"
 routing_key = "#"
 queue = "queue/guest/test"
 password = "guest"
+heartbeat = 30
 ssl = false
 
 [clones]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -116,7 +116,7 @@ def test_no_duplicated_ack_messages(
     test_config: Config,
     get_payload: Callable,
 ) -> None:
-    """This tests checks that long-running messages are not processed more than once.
+    """This test checks that long-running messages are not processed more than once.
 
     It may also timeout, which is likely indicative of the same issue.
     """

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -116,8 +116,7 @@ def test_no_duplicated_ack_messages(
     test_config: Config,
     get_payload: Callable,
 ) -> None:
-    """This tests checkes that a long-running message is not processed more than
-    once.
+    """This tests checks that long-running messages are not processed more than once.
 
     It may also timeout, which is likely indicative of the same issue.
     """

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,7 +1,10 @@
 import os
 import subprocess
+from collections.abc import Callable
 from pathlib import Path
+from time import sleep
 from typing import Any
+from unittest import mock
 
 import kombu
 import pulse_utils
@@ -12,23 +15,15 @@ from utils import hg_cat, hg_log, hg_rev
 
 from git_hg_sync.__main__ import get_connection, get_queue, start_app
 from git_hg_sync.config import Config, PulseConfig
+from git_hg_sync.pulse_worker import PulseWorker
 
 NO_RABBITMQ = os.getenv("RABBITMQ") != "true"
 HERE = Path(__file__).parent
 
 
 @pytest.mark.skipif(NO_RABBITMQ, reason="This test doesn't work without rabbitMq")
-def test_send_and_receive(pulse_config: PulseConfig) -> None:
-    payload = {
-        "type": "push",
-        "repo_url": "repo.git",
-        "branches": {},
-        "tags": {},
-        "time": 0,
-        "push_id": 0,
-        "user": "user",
-        "push_json_url": "push_json_url",
-    }
+def test_send_and_receive(pulse_config: PulseConfig, get_payload: Callable) -> None:
+    payload = get_payload()
 
     def callback(body: Any, message: kombu.Message) -> None:
         message.ack()
@@ -44,6 +39,7 @@ def test_send_and_receive(pulse_config: PulseConfig) -> None:
 @pytest.mark.skipif(NO_RABBITMQ, reason="This test doesn't work without rabbitMq")
 def test_full_app(
     tmp_path: Path,
+    get_payload: Callable,
 ) -> None:
     # With the test configuration, our local branch and tags should map to those
     # destinations.
@@ -92,16 +88,11 @@ def test_full_app(
 
     # send message
     config = Config.from_file(tmp_path / "config.toml")
-    payload = {
-        "type": "push",
-        "repo_url": str(git_remote_repo_path),
-        "branches": {local_branch: git_commit_sha},
-        "tags": {local_tag: git_commit_sha},
-        "time": 0,
-        "push_id": 0,
-        "user": "user",
-        "push_json_url": "push_json_url",
-    }
+    payload = get_payload(
+        repo_url=str(git_remote_repo_path),
+        branches={local_branch: git_commit_sha},
+        tags={local_tag: git_commit_sha},
+    )
     pulse_utils.send_pulse_message(config.pulse, payload, purge=True)
 
     # execute app
@@ -118,3 +109,34 @@ def test_full_app(
     assert "No bug - Tagging" in tag_log
     assert "FIREFOX_128_0esr_RELEASE" in tag_log
     assert hg_rev(hg_remote_repo_path, destination_branch) in tag_log
+
+
+@pytest.mark.skipif(NO_RABBITMQ, reason="This test doesn't work without rabbitMq")
+def test_no_duplicated_ack_messages(
+    test_config: Config,
+    get_payload: Callable,
+) -> None:
+    """This tests checkes that a long-running message is not processed more than
+    once.
+
+    It may also timeout, which is likely indicative of the same issue.
+    """
+    payload = get_payload()
+
+    wait = 30
+
+    connection = get_connection(test_config.pulse)
+    queue = get_queue(test_config.pulse)
+    queue(connection).queue_declare()
+    queue(connection).queue_bind()
+
+    worker = PulseWorker(connection, queue, one_shot=True)
+
+    callback = mock.MagicMock()
+    callback.side_effect = lambda _event: sleep(wait)
+    worker.event_handler = callback
+
+    pulse_utils.send_pulse_message(test_config.pulse, payload, purge=True)
+    worker.run()
+
+    callback.assert_called_once()


### PR DESCRIPTION
We initially had the heartbeat set to a reasonable-looking 10s.

It seems RabbitMQ drops a client after 3 missed heartbeats. However, the Kombu `ConsumerMixin` intertwines heartbeat with message processing, which means that heartbeat checks are missed if a message takes too long to process.

This results in any message taking longer than 30s to process to not be acked before the connection is dropped, and the message reappears at the tip of the queue, ready to be processed again.

While processing the message is now a noop because nothing needs to be pushed, looping over multiple push destinations still ended up taking too long, and caused bug 1980181. As the destinations loop kept happening on every processing of the message, it could never be acked correctly.