### PR TITLE
config: create empty prod-fx config (bug 2016012)

### DIFF
--- a/config-production-firefox.toml
+++ b/config-production-firefox.toml
@@ -1,0 +1,19 @@
+[pulse]
+# Those parameters can be overriden by PULSE_* environment variables
+host = "pulse.mozilla.org"
+port = 5671
+ssl = true
+userid = "SET THIS IN PULSE_USERID ENV VARIABLE"
+password = "SET THIS IN PULSE_PASSWORD ENV VARIABLE"
+# The exchange is declared by the Producer.
+exchange = "exchange/landoprod/pushes"
+routing_key = "gitpushes"
+# The Consumer declares the queue and binds it to the exchange.
+heartbeat = 30
+queue = "queue/githgsyncprod/pushes"
+
+[sentry]
+sentry_dsn = ""
+
+[clones]
+directory = "/clones"


### PR DESCRIPTION
We are preparing to use separate sync workers per target. This empty config is to support spinning up a dedicated firefox worker ahead of time.