### PR TITLE
config: merge all prod config back into a single file (bug 2024547)

### DIFF
--- a/config-production-firefox.toml
+++ b/config-production-firefox.toml
@@ -10,7 +10,7 @@ exchange = "exchange/landoprod/pushes"
 routing_key = "gitpushes.firefox"
 # The Consumer declares the queue and binds it to the exchange.
 heartbeat = 30
-queue = "queue/githgsyncprod/pushes"
+queue = "queue/githgsyncprod/pushes.firefox"
 
 [sentry]
 sentry_dsn = ""

--- a/config-production-firefox.toml
+++ b/config-production-firefox.toml
@@ -7,7 +7,7 @@ userid = "SET THIS IN PULSE_USERID ENV VARIABLE"
 password = "SET THIS IN PULSE_PASSWORD ENV VARIABLE"
 # The exchange is declared by the Producer.
 exchange = "exchange/landoprod/pushes"
-routing_key = "gitpushes"
+routing_key = "gitpushes.firefox"
 # The Consumer declares the queue and binds it to the exchange.
 heartbeat = 30
 queue = "queue/githgsyncprod/pushes"
@@ -24,7 +24,7 @@ directory = "/clones"
 
 [[tracked_repositories]]
 name = "firefox"
-url = "https://github.com/mozilla-firefox/firefox.git_NOT_YET_IN_USE"
+url = "https://github.com/mozilla-firefox/firefox.git_NOT_IN_USE"
 
 
 #
@@ -34,13 +34,13 @@ url = "https://github.com/mozilla-firefox/firefox.git_NOT_YET_IN_USE"
 # references early, with the benefit of bundles.
 #
 [[branch_mappings]]
-source_url = "https://github.com/mozilla-firefox/firefox.git_NOT_YET_IN_USE"
+source_url = "https://github.com/mozilla-firefox/firefox.git_NOT_IN_USE"
 branch_pattern = "THIS_SHOULD_MATCH_NOTHING"
 destination_url = "https://hg.mozilla.org/mozilla-unified/"
 destination_branch = "NOT_A_VALID_BRANCH"
 
 [[tag_mappings]]
-source_url = "https://github.com/mozilla-firefox/firefox.git_NOT_YET_IN_USE"
+source_url = "https://github.com/mozilla-firefox/firefox.git_NOT_IN_USE"
 tag_pattern = "THIS_SHOULD_MATCH_NOTHING"
 destination_url = "https://hg.mozilla.org/mozilla-unified/"
 tags_destination_branch = "NOT_A_VALID_BRANCH"

--- a/config-production-thunderbird.toml
+++ b/config-production-thunderbird.toml
@@ -10,7 +10,7 @@ exchange = "exchange/landoprod/pushes"
 routing_key = "gitpushes.thunderbird"
 # The Consumer declares the queue and binds it to the exchange.
 heartbeat = 30
-queue = "queue/githgsyncprod/pushes"
+queue = "queue/githgsyncprod/pushes.thunderbird"
 
 [sentry]
 sentry_dsn = ""

--- a/config-production-thunderbird.toml
+++ b/config-production-thunderbird.toml
@@ -7,7 +7,7 @@ userid = "SET THIS IN PULSE_USERID ENV VARIABLE"
 password = "SET THIS IN PULSE_PASSWORD ENV VARIABLE"
 # The exchange is declared by the Producer.
 exchange = "exchange/landoprod/pushes"
-routing_key = "gitpushes"
+routing_key = "gitpushes.thunderbird"
 # The Consumer declares the queue and binds it to the exchange.
 heartbeat = 30
 queue = "queue/githgsyncprod/pushes"
@@ -24,7 +24,8 @@ directory = "/clones"
 
 [[tracked_repositories]]
 name = "thunderbird-infra-testing"
-url = "https://github.com/thunderbird/infra-testing.git"
+url = "https://github.com/thunderbird/infra-testing.git_NOT_IN_USE"
+
 
 #
 # COMM-UNIFIED
@@ -33,46 +34,15 @@ url = "https://github.com/thunderbird/infra-testing.git"
 # references early, with the benefit of bundles.
 #
 [[branch_mappings]]
-source_url = "https://github.com/thunderbird/infra-testing.git"
+source_url = "https://github.com/thunderbird/infra-testing.git_NOT_IN_USE"
 branch_pattern = "THIS_SHOULD_MATCH_NOTHING"
 destination_url = "https://hg.mozilla.org/comm-unified/"
 destination_branch = "NOT_A_VALID_BRANCH"
 
-[[branch_mappings]]
-source_url = "https://github.com/thunderbird/infra-testing.git"
-branch_pattern = "main"
-destination_url = "ssh://hg.mozilla.org/conduit-testing/comm-infra-testing/"
-destination_branch = "default"
-
 [[tag_mappings]]
-source_url = "https://github.com/thunderbird/infra-testing.git"
-
-# comm-central:
-# tag_pattern = ".+"
-# destination_url = "ssh://hg.mozilla.org/comm-central"
-# tags_destination_branch = "tags-testing"
-
-# comm-beta:
-# tag_pattern = "(^THUNDERBIRD|NIGHTLY|BETA|RELEASE)_.*$"
-# destination_url = "ssh://hg.mozilla.org/releases/comm-beta/"
-# tags_destination_branch = "tags-unified"
-
-# comm-release:
-# tag_pattern = "(^THUNDERBIRD|NIGHTLY|BETA|RELEASE)_.*$"
-# destination_url = "ssh://hg.mozilla.org/releases/comm-release/"
-# tags_destination_branch = "tags-unified"
-
-# comm-esrXXX
-# tag_pattern = "^(THUNDERBIRD)_(\\d+)(_\\d+)+esr_(BUILD\\d+|RELEASE)$"
-# destination_url = "ssh://hg.mozilla.org/releases/comm-esr\\2/"
-# tags_destination_branch = "tags-unified"
-# ...
-# tag_pattern = "^ESR_(\\d+)_BASE$"
-# destination_url = "ssh://hg.mozilla.org/releases/comm-esr\\1/"
-# tags_destination_branch = "tags-unified"
-
-tag_pattern = ".+"
-destination_url = "ssh://hg.mozilla.org/conduit-testing/comm-infra-testing/"
-tags_destination_branch = "tags-testing"
+source_url = "https://github.com/thunderbird/infra-testing.git_NOT_IN_USE"
+tag_pattern = "THIS_SHOULD_MATCH_NOTHING"
+destination_url = "https://hg.mozilla.org/comm-unified/"
+tags_destination_branch = "NOT_A_VALID_BRANCH"
 # Default
 #tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"

--- a/config-production.toml
+++ b/config-production.toml
@@ -146,9 +146,9 @@ destination_url = "ssh://hg.mozilla.org/releases/mozilla-release/"
 destination_branch = "\\1"
 
 
-#################
-# INFRA-TESTING #
-#################
+###########################
+# (FIREFOX) INFRA-TESTING #
+###########################
 
 [[tracked_repositories]]
 name = "infra-testing"
@@ -186,6 +186,66 @@ destination_branch = "\\1"
 source_url = "https://github.com/mozilla-firefox/infra-testing.git"
 tag_pattern = ".+"
 destination_url = "ssh://hg.mozilla.org/conduit-testing/infra-testing/"
+tags_destination_branch = "tags-testing"
+# Default
+#tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"
+
+
+#############################
+# THUNDERBIRD-INFRA-TESTING #
+#############################
+
+[[tracked_repositories]]
+name = "thunderbird-infra-testing"
+url = "https://github.com/thunderbird/infra-testing.git"
+
+#
+# COMM-UNIFIED
+#
+# We don't sync to this repository, but we put it here first to fetch all
+# references early, with the benefit of bundles.
+#
+[[branch_mappings]]
+source_url = "https://github.com/thunderbird/infra-testing.git"
+branch_pattern = "THIS_SHOULD_MATCH_NOTHING"
+destination_url = "https://hg.mozilla.org/comm-unified/"
+destination_branch = "NOT_A_VALID_BRANCH"
+
+[[branch_mappings]]
+source_url = "https://github.com/thunderbird/infra-testing.git"
+branch_pattern = "main"
+destination_url = "ssh://hg.mozilla.org/conduit-testing/comm-infra-testing/"
+destination_branch = "default"
+
+[[tag_mappings]]
+source_url = "https://github.com/thunderbird/infra-testing.git"
+
+# comm-central:
+# tag_pattern = ".+"
+# destination_url = "ssh://hg.mozilla.org/comm-central"
+# tags_destination_branch = "tags-testing"
+
+# comm-beta:
+# tag_pattern = "(^THUNDERBIRD|NIGHTLY|BETA|RELEASE)_.*$"
+# destination_url = "ssh://hg.mozilla.org/releases/comm-beta/"
+# tags_destination_branch = "tags-unified"
+
+# comm-release:
+# tag_pattern = "(^THUNDERBIRD|NIGHTLY|BETA|RELEASE)_.*$"
+# destination_url = "ssh://hg.mozilla.org/releases/comm-release/"
+# tags_destination_branch = "tags-unified"
+
+# comm-esrXXX
+# tag_pattern = "^(THUNDERBIRD)_(\\d+)(_\\d+)+esr_(BUILD\\d+|RELEASE)$"
+# destination_url = "ssh://hg.mozilla.org/releases/comm-esr\\2/"
+# tags_destination_branch = "tags-unified"
+# ...
+# tag_pattern = "^ESR_(\\d+)_BASE$"
+# destination_url = "ssh://hg.mozilla.org/releases/comm-esr\\1/"
+# tags_destination_branch = "tags-unified"
+
+tag_pattern = ".+"
+destination_url = "ssh://hg.mozilla.org/conduit-testing/comm-infra-testing/"
 tags_destination_branch = "tags-testing"
 # Default
 #tag_message_suffix = "a=tagging CLOSED TREE DONTBUILD"


### PR DESCRIPTION
Workload selection is now done via the `PULSE_ROUTING_KEY` set in the environment of each deployment.

We retain the -firefox and -thunderbird configuration files as noop for now. This is to avoid unexpected failures with current deployments that may still be looking for them. They also update the `routing_key` and `queue`, to match what future environments should set for `PULSE_ROUTING_KEY` and `PULSE_QUEUE` (see https://github.com/mozilla/webservices-infra/pull/10205), so that workers started with those configurations don't mistakenly grab messages that should have been processed by others.