### PR TITLE
config-prod: remove -unified repos from infra-testing configs (bug 2039172)

### DIFF
--- a/config-production.toml
+++ b/config-production.toml
@@ -154,21 +154,6 @@ destination_branch = "\\1"
 name = "infra-testing"
 url = "https://github.com/mozilla-firefox/infra-testing.git"
 
-#
-# MOZILLA-UNIFIED
-#
-# We don't sync to this repository, but we put it here first to fetch all
-# references early, with the benefit of bundles.
-#
-# XXX: For this to work, https://github.com/mozilla-firefox/infra-testing.git needs
-# to have all commits presents on https://github.com/mozilla-firefox/firefox.git.
-#
-[[branch_mappings]]
-source_url = "https://github.com/mozilla-firefox/infra-testing.git"
-branch_pattern = "THIS_SHOULD_MATCH_NOTHING"
-destination_url = "https://hg.mozilla.org/mozilla-unified/"
-destination_branch = "NOT_A_VALID_BRANCH"
-
 [[branch_mappings]]
 source_url = "https://github.com/mozilla-firefox/infra-testing.git"
 branch_pattern = "autoland"

--- a/config-production.toml
+++ b/config-production.toml
@@ -190,11 +190,11 @@ url = "https://github.com/thunderbird/infra-testing.git"
 # We don't sync to this repository, but we put it here first to fetch all
 # references early, with the benefit of bundles.
 #
-[[branch_mappings]]
-source_url = "https://github.com/thunderbird/infra-testing.git"
-branch_pattern = "THIS_SHOULD_MATCH_NOTHING"
-destination_url = "https://hg.mozilla.org/comm-unified/"
-destination_branch = "NOT_A_VALID_BRANCH"
+# [[branch_mappings]]
+# source_url = "https://github.com/thunderbird/infra-testing.git"
+# branch_pattern = "THIS_SHOULD_MATCH_NOTHING"
+# destination_url = "https://hg.mozilla.org/comm-unified/"
+# destination_branch = "NOT_A_VALID_BRANCH"
 
 [[branch_mappings]]
 source_url = "https://github.com/thunderbird/infra-testing.git"


### PR DESCRIPTION
While the bundles were useful to start with, now that the infra-testing repos have diverged, they confused git-cinnabar when trying to find matching commits to graft.