### PR TITLE
repo_synchroniser: use Git.clone_from to init repo (bug 1962599)

### DIFF
--- a/config-production.toml
+++ b/config-production.toml
@@ -154,6 +154,21 @@ destination_branch = "\\1"
 name = "infra-testing"
 url = "https://github.com/mozilla-firefox/infra-testing.git"
 
+#
+# MOZILLA-UNIFIED
+#
+# We don't sync to this repository, but we put it here first to fetch all
+# references early, with the benefit of bundles.
+#
+# XXX: For this to work, https://github.com/mozilla-firefox/infra-testing.git needs
+# to have all commits presents on https://github.com/mozilla-firefox/firefox.git.
+#
+[[branch_mappings]]
+source_url = "https://github.com/mozilla-firefox/infra-testing.git"
+branch_pattern = "THIS_SHOULD_MATCH_NOTHING"
+destination_url = "https://hg.mozilla.org/mozilla-unified/"
+destination_branch = "NOT_A_VALID_BRANCH"
+
 [[branch_mappings]]
 source_url = "https://github.com/mozilla-firefox/infra-testing.git"
 branch_pattern = "autoland"

--- a/config-production.toml
+++ b/config-production.toml
@@ -154,21 +154,6 @@ destination_branch = "\\1"
 name = "infra-testing"
 url = "https://github.com/mozilla-firefox/infra-testing.git"
 
-#
-# MOZILLA-UNIFIED
-#
-# We don't sync to this repository, but we put it here first to fetch all
-# references early, with the benefit of bundles.
-#
-# XXX: For this to work, https://github.com/mozilla-firefox/infra-testing.git needs
-# to have all commits presents on https://github.com/mozilla-firefox/firefox.git.
-#
-[[branch_mappings]]
-source_url = "https://github.com/mozilla-firefox/infra-testing.git"
-branch_pattern = "THIS_SHOULD_MATCH_NOTHING"
-destination_url = "https://hg.mozilla.org/mozilla-unified/"
-destination_branch = "NOT_A_VALID_BRANCH"
-
 [[branch_mappings]]
 source_url = "https://github.com/mozilla-firefox/infra-testing.git"
 branch_pattern = "autoland"

--- a/git_hg_sync/repo_synchronizer.py
+++ b/git_hg_sync/repo_synchronizer.py
@@ -41,12 +41,16 @@ class RepoSynchronizer:
         if self._clone_directory.exists():
             repo = Repo(self._clone_directory)
         else:
-            repo = Repo.init(self._clone_directory)
+            repo = Repo.clone_from(
+                self._src_remote,
+                self._clone_directory,
+                multi_options=[
+                    '--config cinnabar.experiments="branch,tag,git_commit,merge"',
+                ],
+                allow_unsafe_options=True,
+                bare=True,
+            )
 
-        # Ensure that the clone repository is well configured
-        with repo.config_writer() as config:
-            config.add_section("cinnabar")
-            config.set("cinnabar", "experiments", "branch,tag,git_commit,merge")
         return repo
 
     def _commit_has_mercurial_metadata(self, repo: Repo, git_commit: str) -> bool:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 from collections.abc import Callable
+from configparser import ConfigParser
 from pathlib import Path
 from time import sleep
 from typing import Any
@@ -109,7 +110,8 @@ def test_full_app(
     subprocess.run(["hg", "init"], cwd=hg_remote_repo_path, check=True)
 
     # Create a remote git repository
-    git_remote_repo_path = tmp_path / "git-remotes" / "firefox-releases"
+    git_repo_name = "firefox-releases"
+    git_remote_repo_path = tmp_path / "git-remotes" / git_repo_name
     # Create an initial commit on git
     repo = Repo.init(git_remote_repo_path, b="esr128")
     foo_path = git_remote_repo_path / "foo.txt"
@@ -152,6 +154,22 @@ def test_full_app(
 
     # execute app
     start_app(config, get_proxy_logger("test"), one_shot=True)
+
+    # test that the working repository is a bare repo
+    git_clone_config_path = config.clones.directory / git_repo_name / "config"
+    assert not (git_clone_config_path / ".git").exists(), (
+        "Found .git in {git_clone_config_path}, it should be a bare repo"
+    )
+    assert git_clone_config_path.exists(), (
+        "Cannot find git clone config at {git_clone_config_path}, is it a bare repo?"
+    )
+    git_clone_config = ConfigParser()
+    with git_clone_config_path.open("r") as fp:
+        git_clone_config.read_file(fp)
+    assert git_clone_config["core"]["bare"], "Working copy clone is not a bare repo"
+    assert (
+        git_clone_config["cinnabar"]["experiments"] == "branch,tag,git_commit,merge"
+    ), "Incorrect git cinnabar.experiments configuration set"
 
     # test
     assert "BAR CONTENT" in hg_cat(hg_remote_repo_path, "bar.txt", destination_branch)


### PR DESCRIPTION
 * repo_synchroniser: use Git.clone_from to init repo (bug 1962599)
 * test_integration: ensure that the working clone is a bare repo