### PR TITLE
repo_synchroniser: only dry-run as necessary, and rollback prior to pushing for real (bug 2012575)

### DIFF
--- a/config-production.toml
+++ b/config-production.toml
@@ -154,21 +154,6 @@ destination_branch = "\\1"
 name = "infra-testing"
 url = "https://github.com/mozilla-firefox/infra-testing.git"
 
-#
-# MOZILLA-UNIFIED
-#
-# We don't sync to this repository, but we put it here first to fetch all
-# references early, with the benefit of bundles.
-#
-# XXX: For this to work, https://github.com/mozilla-firefox/infra-testing.git needs
-# to have all commits presents on https://github.com/mozilla-firefox/firefox.git.
-#
-[[branch_mappings]]
-source_url = "https://github.com/mozilla-firefox/infra-testing.git"
-branch_pattern = "THIS_SHOULD_MATCH_NOTHING"
-destination_url = "https://hg.mozilla.org/mozilla-unified/"
-destination_branch = "NOT_A_VALID_BRANCH"
-
 [[branch_mappings]]
 source_url = "https://github.com/mozilla-firefox/infra-testing.git"
 branch_pattern = "autoland"

--- a/git_hg_sync/repo_synchronizer.py
+++ b/git_hg_sync/repo_synchronizer.py
@@ -158,23 +158,6 @@ class RepoSynchronizer:
         os.environ["GIT_AUTHOR_NAME"] = userinfo
         logger.debug(f"{REQUEST_USER_ENV_VAR} and GIT_AUTHOR_* set to {request_user}")
 
-        # Add mercurial metadata to new commits from synced branches
-        # Some of these commits could be tagged in the same synchronization and
-        # tagging can only be done on a commit that already have mercurial
-        # metadata
-        if branch_ops:
-            retry(
-                "adding mercurial metadata to git commits",
-                lambda: repo.git.execute(
-                    ["git"]
-                    + ["-c", "cinnabar.data=force"]
-                    + ["push"]
-                    + ["--dry-run"]
-                    + [destination_remote]
-                    + refs_to_push,
-                ),
-            )
-
         # Handle tag operations
         tag_ops: list[SyncTagOperation] = [
             op for op in operations if isinstance(op, SyncTagOperation)
@@ -214,12 +197,42 @@ class RepoSynchronizer:
                 )
 
         # Create tags
+
+        # In bug 2012575, we ran into an issue where cinnabar's common-commit detection
+        # logic hit an octopus merge that it didn't like once Hg metadata was populated.
+        # We therefore need to rollback the metadata prior to pushing the new commits
+        # for real, to avoid this issue, and we need to know where to roll it back to.
+        rollback_candidate = None
+
         tag_branches_to_push = set()
         for tag_operation in tag_ops:
+
             if not self._commit_has_mercurial_metadata(
                 repo, tag_operation.source_commit
             ):
-                raise MercurialMetadataNotFoundError(tag_operation)
+                rollback_candidate = self._get_current_cinnabar_state(repo)
+
+                # Tagging can only be done on a commit that already has mercurial
+                # metadata.
+                #
+                # Add mercurial metadata to new commits from synced branches.
+                retry(
+                        "adding mercurial metadata to new git commits for tagging",
+                        lambda: repo.git.execute(
+                            ["git"]
+                            + ["-c", "cinnabar.data=force"]
+                            + ["push"]
+                            + ["--dry-run"]
+                            + [destination_remote]
+                            + refs_to_push,
+                            ),
+                        )
+
+                # Make sure it worked.
+                if not self._commit_has_mercurial_metadata(
+                    repo, tag_operation.source_commit
+                ):
+                    raise MercurialMetadataNotFoundError(tag_operation)
 
             hg_sha = self._git2hg(repo, tag_operation.source_commit)
             tag_message = f"No bug - Tagging {hg_sha} with {tag_operation.tag} {tag_operation.tag_message_suffix}"
@@ -247,6 +260,10 @@ class RepoSynchronizer:
                 raise RepoSyncError(tag_operation, exc) from exc
 
             tag_branches_to_push.add(tag_operation.tags_destination_branch)
+
+        if rollback_candidate:
+            logger.debug("rolling back cinnabar metadata update for new commits before push")
+            self._rollback_cinnabar_state(repo, rollback_candidate)
 
         for tag_branch in tag_branches_to_push:
             refs_to_push.append(f"{tag_branch}:{self._cinnabar_branch(tag_branch)}")
@@ -301,6 +318,13 @@ class RepoSynchronizer:
 
     def _git2hg(self, repo: Repo, git_commit: str) -> str:
         return repo.git.cinnabar(["git2hg", git_commit]).strip()
+
+    def _get_current_cinnabar_state(self, repo: Repo) -> str:
+        candidates: str = repo.git.cinnabar(["rollback", "--candidates"]).strip()
+        return candidates.split(maxsplit=1)[0]
+
+    def _rollback_cinnabar_state(self, repo: Repo, rollback_candidate: str) -> None:
+        repo.git.cinnabar(["rollback", rollback_candidate])
 
     def _cinnabar_branch(self, branch: str) -> str:
         return f"refs/heads/branches/{branch}/tip"

--- a/git_hg_sync/repo_synchronizer.py
+++ b/git_hg_sync/repo_synchronizer.py
@@ -41,12 +41,16 @@ class RepoSynchronizer:
         if self._clone_directory.exists():
             repo = Repo(self._clone_directory)
         else:
-            repo = Repo.init(self._clone_directory)
+            repo = Repo.clone_from(
+                self._src_remote,
+                self._clone_directory,
+                multi_options=[
+                    '--config cinnabar.experiments="branch,tag,git_commit,merge"',
+                ],
+                allow_unsafe_options=True,
+                bare=True,
+            )
 
-        # Ensure that the clone repository is well configured
-        with repo.config_writer() as config:
-            config.add_section("cinnabar")
-            config.set("cinnabar", "experiments", "branch,tag,git_commit,merge")
         return repo
 
     def _commit_has_mercurial_metadata(self, repo: Repo, git_commit: str) -> bool:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 from collections.abc import Callable
+from configparser import ConfigParser
 from pathlib import Path
 from time import sleep
 from typing import Any
@@ -109,7 +110,8 @@ def test_full_app(
     subprocess.run(["hg", "init"], cwd=hg_remote_repo_path, check=True)
 
     # Create a remote git repository
-    git_remote_repo_path = tmp_path / "git-remotes" / "firefox-releases"
+    git_repo_name = "firefox-releases"
+    git_remote_repo_path = tmp_path / "git-remotes" / git_repo_name
     # Create an initial commit on git
     repo = Repo.init(git_remote_repo_path, b="esr128")
     foo_path = git_remote_repo_path / "foo.txt"
@@ -152,6 +154,22 @@ def test_full_app(
 
     # execute app
     start_app(config, get_proxy_logger("test"), one_shot=True)
+
+    # test that the working repository is a bare repo
+    git_clone_config_path = config.clones.directory / git_repo_name / "config"
+    assert not (git_clone_config_path / ".git").exists(), (
+        "Found .git in {git_clone_config_path}, it should be a bare repo"
+    )
+    assert git_clone_config_path.exists(), (
+        "Cannot find git clone config at {git_clone_config_path}, is it a bare repo?"
+    )
+    git_clone_config = ConfigParser()
+    with git_clone_config_path.open("r") as fp:
+        git_clone_config.read_file(fp)
+    assert git_clone_config["core"]["bare"], "Working copy clone is not a bare repo"
+    assert (
+        git_clone_config["cinnabar"]["experiments"] == "branch,tag,git_commit,merge"
+    ), "Incorrect git cinnabar.experiments configuration set"
 
     # test
     assert "BAR CONTENT" in hg_cat(hg_remote_repo_path, "bar.txt", destination_branch)


### PR DESCRIPTION
The `push --dry-run` is used to generate HG changeset IDs for new commits. This is only necessary if we are going to tag those commits in the same operation.

However, when cinnabar has commits with HG metadata but not yet present on the remote, it tries to find a common base iteratively. In the case of `thunderbird/infra-testing`, this approach finds an octopus merge which doesn't satisfy some of cinnabar's pre-conditions, and fails.

In practice, we rarely (never, at the time of this writing) push and tag a commit in the same operation, so this step can be skipped. If any commit to be tagged is missing cinnabar metadata, we fall back to running the `push --dry-run` nonetheless.

Moreover, as per bug 2039806, this step almost doubles the time it takes to sync large pushes at release time.