### PR TITLE
deps: bump to cinnabar 0.7.4 (bug 2030243)

### DIFF
--- a/install_git-cinnabar.sh
+++ b/install_git-cinnabar.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-VER=71ac248b7dd7b56ac2cfe764c914a6a3025ea5af
+VER=f434ffd01405f62151f702fcf0593fe4c0dd45ea # 0.7.4
 
 curl https://raw.githubusercontent.com/glandium/git-cinnabar/${VER}/download.py -o download.py
 chmod u+x download.py

--- a/install_git-cinnabar.sh
+++ b/install_git-cinnabar.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 
-VER=f434ffd01405f62151f702fcf0593fe4c0dd45ea # 0.7.4
+VER=f434ffd01405f62151f702fcf0593fe4c0dd45ea
+# Comment this out if not currently relying on a release.
+TAG=0.7.4
 
 curl https://raw.githubusercontent.com/glandium/git-cinnabar/${VER}/download.py -o download.py
 chmod u+x download.py
-./download.py --exact ${VER}
+./download.py --exact ${TAG:-${VER}}
 chmod a+x git-cinnabar
 chmod a+x git-remote-hg


### PR DESCRIPTION
 * deps: bump to cinnabar 0.7.4
 * deps: support passing cinnabar tag to download script
  
    This makes it download the release tarball from GitHub, rather than
    relying on a transient build from TaskCluster.